### PR TITLE
feat: added Button widget use-case and Widgetbook setup

### DIFF
--- a/widgetbook/lib/button.dart
+++ b/widgetbook/lib/button.dart
@@ -1,0 +1,14 @@
+import 'package:flutter/material.dart';
+import 'package:widgetbook_annotation/widgetbook_annotation.dart' as widgetbook;
+// Import your Button widget from your main app
+import 'package:widgetbook_app/button/button.dart';
+
+@widgetbook.UseCase(name: 'Default', type: Button)
+Widget buildButtonUseCase(BuildContext context) {
+  return Button(
+    text: 'Button',
+    onPressed: () {
+      debugPrint('Button pressed');
+    },
+  );
+}

--- a/widgetbook/lib/main.dart
+++ b/widgetbook/lib/main.dart
@@ -1,20 +1,21 @@
 import 'package:flutter/material.dart';
+import 'package:widgetbook/widgetbook.dart';
+import 'package:widgetbook_annotation/widgetbook_annotation.dart' as widgetbook;
+import 'main.directories.g.dart';
 
 void main() {
-  runApp(const MainApp());
+  runApp(const WidgetbookApp());
 }
 
-class MainApp extends StatelessWidget {
-  const MainApp({super.key});
+@widgetbook.App()
+class WidgetbookApp extends StatelessWidget {
+  const WidgetbookApp({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return const MaterialApp(
-      home: Scaffold(
-        body: Center(
-          child: Text('Hello World!'),
-        ),
-      ),
+    return Widgetbook.material(
+      directories: directories,
     );
   }
 }
+

--- a/widgetbook/lib/main.directories.g.dart
+++ b/widgetbook/lib/main.directories.g.dart
@@ -1,0 +1,32 @@
+// dart format width=80
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_import, prefer_relative_imports, directives_ordering
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// **************************************************************************
+// AppGenerator
+// **************************************************************************
+
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'package:widgetbook/widgetbook.dart' as _widgetbook;
+import 'package:widgetbook_workspace/button.dart'
+    as _widgetbook_workspace_button;
+
+final directories = <_widgetbook.WidgetbookNode>[
+  _widgetbook.WidgetbookFolder(
+    name: 'button',
+    children: [
+      _widgetbook.WidgetbookComponent(
+        name: 'Button',
+        useCases: [
+          _widgetbook.WidgetbookUseCase(
+            name: 'Default',
+            builder: _widgetbook_workspace_button.buildButtonUseCase,
+          ),
+        ],
+      ),
+    ],
+  ),
+];

--- a/widgetbook/pubspec.lock
+++ b/widgetbook/pubspec.lock
@@ -153,6 +153,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.7"
+  cupertino_icons:
+    dependency: transitive
+    description:
+      name: cupertino_icons
+      sha256: ba631d1c7f7bef6b729a622b7b752645a2d076dba9976925b8f25725a30e1ee6
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.8"
   dart_style:
     dependency: transitive
     description:
@@ -629,6 +637,13 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.9.0"
+  widgetbook_app:
+    dependency: "direct main"
+    description:
+      path: ".."
+      relative: true
+    source: path
+    version: "1.0.0+1"
   widgetbook_generator:
     dependency: "direct dev"
     description:

--- a/widgetbook/pubspec.yaml
+++ b/widgetbook/pubspec.yaml
@@ -11,6 +11,8 @@ dependencies:
     sdk: flutter
   widgetbook: ^3.20.2
   widgetbook_annotation: ^3.9.0
+  widgetbook_app:
+    path: ../
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
Sets up Widgetbook to display it as a use-case. Widgetbook is now fully configured and running locally.

### Dependencies
- Added `widgetbook_app` as path dependency in `widgetbook/pubspec.yaml`
- All Widgetbook dependencies already configured in previous PR

## Testing
- ✅ Widgetbook runs successfully on localhost
- ✅ Button component displays correctly in Widgetbook UI
- ✅ Use-case is accessible in the catalog
